### PR TITLE
manage decompress use case

### DIFF
--- a/progress.c
+++ b/progress.c
@@ -772,7 +772,7 @@ for (i = 0 ; i < pid_count ; i++) {
         if (flag_open_mode == PM_WRITE && fdinfo.mode != PM_WRITE && fdinfo.mode != PM_READWRITE)
             continue;
 
-        if (fdinfo.size > max_size) {
+        if (fdinfo.size>fdinfo.pos*1.0001 && fdinfo.size > max_size) {
             biggest_fd = fdinfo;
             max_size = fdinfo.size;
         }


### PR DESCRIPTION
When using `progress` for a process which produce biggest output than input
such as decompression process, the biggest file is not the interesting one because it is always close 100%
The modification ignore the files where 99.9% of progress is done to account this use case.